### PR TITLE
Updated email field on config file

### DIFF
--- a/library.json
+++ b/library.json
@@ -10,7 +10,7 @@
 	"authors": [
 		{
 			"name": "David Johnson-Davies",
-			"email": "david@technoblogy.com ",
+			"email": "david@technoblogy.com",
 			"url": "https://github.com/technoblogy/tiny-i2c",
 			"maintainer": true
 		}


### PR DESCRIPTION
The email field had a dangling whitespace.
```
pio pkg publish
Preparing a package...
Error: Invalid manifest fields: {'authors': {0: {'email': ['Not a valid email address.']}}}.
Please check specification -> https://docs.platformio.org/page/librarymanager/config.html
```